### PR TITLE
Hotfix translate words

### DIFF
--- a/deep_translator/linguee.py
+++ b/deep_translator/linguee.py
@@ -125,6 +125,6 @@ class LingueeTranslator(BaseTranslator):
 
         translated_words = []
         for word in words:
-            translated_words.append(self.translate(payload=word))
+            translated_words.append(self.translate(word=word))
         return translated_words
 

--- a/deep_translator/pons.py
+++ b/deep_translator/pons.py
@@ -131,6 +131,6 @@ class PonsTranslator(BaseTranslator):
 
         translated_words = []
         for word in words:
-            translated_words.append(self.translate(payload=word))
+            translated_words.append(self.translate(word=word))
         return translated_words
 

--- a/deep_translator/tests/test_linguee.py
+++ b/deep_translator/tests/test_linguee.py
@@ -47,3 +47,8 @@ def test_payload(linguee):
 
     with pytest.raises(exceptions.NotValidLength):
         linguee.translate("a"*51)
+
+
+def test_translate_words(linguee):
+    words = ['hello', 'world']
+    translated_words = linguee.translate_words(words)

--- a/deep_translator/tests/test_pons.py
+++ b/deep_translator/tests/test_pons.py
@@ -46,3 +46,8 @@ def test_payload(pons):
 
     with pytest.raises(exceptions.NotValidLength):
         pons.translate("a" * 51)
+
+
+def test_translate_words(pons):
+    words = ['hello', 'world']
+    translated_words = pons.translate_words(words)


### PR DESCRIPTION
There is a bug related with Pons and Linguee providers when translating words with ```translate_words()``` method.

```
in translate_words(self, words, **kwargs)
translated_words = []
for word in words:
    translated_words.append(self.translate(payload=word))
return translated_words
TypeError: translate() missing 1 required positional argument: 'word'
```

Fixed changing the argument name to word. Added two tests to check that is working correctly.