### PR TITLE
One character words

### DIFF
--- a/deep_translator/parent.py
+++ b/deep_translator/parent.py
@@ -64,7 +64,7 @@ class BaseTranslator(ABC):
         @param max_chars: maximum characters allowed
         @return: bool
         """
-        return True if min_chars < len(payload) < max_chars else False
+        return True if min_chars <= len(payload) < max_chars else False
 
     @abstractmethod
     def translate(self, text, **kwargs):

--- a/deep_translator/tests/test_google_trans.py
+++ b/deep_translator/tests/test_google_trans.py
@@ -58,3 +58,7 @@ def test_payload(google_translator):
 
     #for _ in range(1):
     #assert google_translator.translate(text='좋은') == "good"
+
+
+def test_one_character_words():
+    assert GoogleTranslator(source='es', target='en').translate('o') == 'or'

--- a/deep_translator/tests/test_linguee.py
+++ b/deep_translator/tests/test_linguee.py
@@ -47,3 +47,7 @@ def test_payload(linguee):
 
     with pytest.raises(exceptions.NotValidLength):
         linguee.translate("a"*51)
+
+
+def test_one_character_words():
+    assert LingueeTranslator(source='es', target='en').translate('y') == 'and'

--- a/deep_translator/tests/test_mymemory.py
+++ b/deep_translator/tests/test_mymemory.py
@@ -46,3 +46,8 @@ def test_payload(mymemory):
 
     with pytest.raises(exceptions.NotValidLength):
         mymemory.translate(text="a"*501)
+
+
+def test_one_character_words(mymemory):
+    assert mymemory.translate('I')
+

--- a/deep_translator/tests/test_pons.py
+++ b/deep_translator/tests/test_pons.py
@@ -46,3 +46,7 @@ def test_payload(pons):
 
     with pytest.raises(exceptions.NotValidLength):
         pons.translate("a" * 51)
+
+
+def test_one_character_words(pons):
+    assert pons.translate('I')


### PR DESCRIPTION
In many languages are words with just one character like: 'I' in english, 'y' in spanish... so I needed to translate texts word by word and had exceptions about the valid length.

I have change the words length interval including the min_chars and added some tests about that.