### PR TITLE
Added functionality for -lang/--languages flag to the CLI usage to return the languages supported by the chosen translator service.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -486,7 +486,7 @@ the right arguments, which are the translator you want to use, source language, 
 you want to translate.
 
 For example, provide "google" as an argument to use the google translator. Alternatively you can use
-the other supported translators.
+the other supported translators. Just read the documentation to have an overview about the supported translators in this library.
 
 .. code-block:: console
 

--- a/README.rst
+++ b/README.rst
@@ -486,8 +486,7 @@ the right arguments, which are the translator you want to use, source language, 
 you want to translate.
 
 For example, provide "google" as an argument to use the google translator. Alternatively you can use
-the other supported translators. Just read the documentation to have an overview about the supported
-translators in this library.
+the other supported translators.
 
 .. code-block:: console
 
@@ -504,6 +503,12 @@ If you want, you can also pass the source and target language by their abbreviat
 .. code-block:: console
 
     $ deep_translator -trans "google" -src "en" -tg "de" -txt "happy coding"
+
+If you want the list of languages supported by a translator service, just pass the translator service as an argument to the -trans flag followed by the -lang/--languages flag. For example:
+
+.. code-block:: console
+
+    $ deep_translator -trans "google" -lang
 
 ======
 Tests
@@ -619,4 +624,3 @@ Here are some screenshots:
     :width: 100%
     :height: 300
     :alt: screenshot3
-

--- a/deep_translator/cli.py
+++ b/deep_translator/cli.py
@@ -30,6 +30,27 @@ def translate(args):
     print(" | Translation from {} to {} |".format(args.source, args.target))
     print("Translated text: \n {}".format(res))
 
+def return_supported_languages(args):
+    """
+    function used to return the languages supported by the translator service from the parsed terminal arguments
+    @param args: parsed terminal arguments
+    @return: None
+    """
+    if args.translator == 'google':
+        translator = GoogleTranslator
+    elif args.translator == 'pons':
+        translator = PonsTranslator
+    elif args.translator == 'linguee':
+        translator = LingueeTranslator
+    elif args.translator == 'mymemory':
+        translator = MyMemoryTranslator
+    else:
+        print("given translator is not supported. Please use a supported translator from the deep_translator tool")
+
+    translator_supported_languages = translator.get_supported_languages(as_dict=True)
+    print(f'Languages supported by \'{args.translator}\' are :\n')
+    print(translator_supported_languages)
+
 
 def main():
     """
@@ -38,13 +59,17 @@ def main():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('--translator', '-trans',
-                        default='google', type=str, help="name of the translator you want to use")
-    parser.add_argument('--source', '-src', type=str, help="source language to translate from", required=True)
-    parser.add_argument('--target', '-tg', type=str, help="target language to translate to", required=True)
-    parser.add_argument('--text', '-txt', type=str, help="text you want to translate", required=True)
+                        default='google', type=str, help="name of the translator you want to use", required=True)
+    parser.add_argument('--source', '-src', type=str, help="source language to translate from")
+    parser.add_argument('--target', '-tg', type=str, help="target language to translate to")
+    parser.add_argument('--text', '-txt', type=str, help="text you want to translate")
+    parser.add_argument('--languages', '-lang',action='store_true', help="all the languages available with the translator. Run the command deep_translator -trans <translator service> -lang")
 
     args = parser.parse_args()
-    translate(args)
+    if args.languages:
+        return_supported_languages(args)
+    else:
+        translate(args)
     # sys.exit()
 
 


### PR DESCRIPTION
Hey @nidhaloff. I have added a bit of a functionality to the cli.py file that adds support for a -lang/--languages flag that takes in the -trans flag with the argument and returns the languages supported by the chosen translator service, in the form of a dictionary with language along with its abbreviation. I have updated the README as well to incorporate this functionality as documentation.

Please go through it once and do let me know if any further changes/optimizations could be made. I am actually new to open source contributions and it would be of great help if you could guide me if everything I have done up to this point is in line with the general workflow and guidelines of contributing.