### PR TITLE
Feature/Implemented get_supported_languages() for DeepL and QCRI translators

### DIFF
--- a/deep_translator/deepl.py
+++ b/deep_translator/deepl.py
@@ -62,11 +62,12 @@ class DeepL(object):
 
     def translate_batch(self, batch, **kwargs):
         """
-        @param batch: list of texts to translate
+        @param batch: list of texts to translate    
         @return: list of translations
         """
         return [self.translate(text, **kwargs) for text in batch]
 
+    @staticmethod
     def get_supported_languages(**kwargs):
         return [*DeepL._languages.keys()]
 

--- a/deep_translator/deepl.py
+++ b/deep_translator/deepl.py
@@ -67,6 +67,9 @@ class DeepL(object):
         """
         return [self.translate(text, **kwargs) for text in batch]
 
+    def get_supported_languages(**kwargs):
+        return [*DeepL._languages.keys()]
+
     def _is_language_supported(self, lang, **kwargs):
         # The language is supported when is in the dicionary.
         return lang == 'auto' or lang in self._languages.keys() or lang in self._languages.values()

--- a/deep_translator/qcri.py
+++ b/deep_translator/qcri.py
@@ -38,6 +38,7 @@ class QCRI(object):
         except Exception as e:
             raise e
 
+    @staticmethod
     def get_supported_languages(**kwargs):
         # Have no use for this as the format is not what we need
         # Save this for whenever

--- a/deep_translator/qcri.py
+++ b/deep_translator/qcri.py
@@ -38,12 +38,12 @@ class QCRI(object):
         except Exception as e:
             raise e
 
-    def get_supported_languages(self, **kwargs):
+    def get_supported_languages(**kwargs):
         # Have no use for this as the format is not what we need
         # Save this for whenever
-        pairs = self._get("get_languages")
+        # pairs = self._get("get_languages")
         # Using a this one instead
-        return QCRI_LANGUAGE_TO_CODE
+        return [*QCRI_LANGUAGE_TO_CODE.keys()]
 
     @property
     def languages(self):


### PR DESCRIPTION
Function get_supported_languages() is implemented for DeepL and QCRI translators, as asked in feature request #69 

get_supported_languages(), will return a list of supported languages, as below

```
<class 'deep_translator.deepl.DeepL'>
['bulgarian', 'czech', 'danish', 'german', 'greek', 'english', 'spanish', 'estonian', 'finnish', 'french', 'hungarian', 'italian', 'japanese', 'lithuanian', 'latvian', 'dutch', 'polish', 'portuguese', 'romanian', 'russian', 'slovak', 'slovenian', 'swedish', 'chinese']

```
```
<class 'deep_translator.qcri.QCRI'>
['Arabic', 'English', 'Spanish']
```
