### PR TITLE
Bug fix in google_trans.py 

### DIFF
--- a/deep_translator/google_trans.py
+++ b/deep_translator/google_trans.py
@@ -36,7 +36,7 @@ class GoogleTranslator(BaseTranslator):
                                                element_tag='div',
                                                element_query={"class": "t0"},
                                                payload_key='q',  # key of text in the url
-                                               hl=self._target,
+                                               tl=self._target,
                                                sl=self._source,
                                                **kwargs)
 

--- a/deep_translator/google_trans.py
+++ b/deep_translator/google_trans.py
@@ -90,9 +90,7 @@ class GoogleTranslator(BaseTranslator):
             if self.payload_key:
                 self._url_params[self.payload_key] = text
             
-            # temporary fix the problem with translation Russian into Ukrainian
-            if self._source == 'ru' and self._target == 'uk':
-                self._url_params['tl'] = 'uk'
+      
 
             response = requests.get(self.__base_url,
                                     params=self._url_params,


### PR DESCRIPTION
Close #90 
Close #52 
```
 super(GoogleTranslator, self).__init__(base_url=self.__base_url,
                                               source=self._source,
                                               target=self._target,
                                               element_tag='div',
                                               element_query={"class": "t0"},
                                               payload_key='q',  # key of text in the url
                                               tl=self._target,
                                               sl=self._source,
                                               **kwargs)
```

This code fixes the above issues, I have been experimenting for a week to figure it out, also this fix doesn't cause issues with any other language.
We can not assign ```self._target``` to ```hl```.