### PR TITLE
Add new languages to DeepL supported language list

### DIFF
--- a/deep_translator/constants.py
+++ b/deep_translator/constants.py
@@ -217,6 +217,7 @@ DEEPL_LANGUAGE_TO_CODE = {
     "finnish": "fi",
     "french": "fr",
     "hungarian": "hu",
+    "indonesian": "id",
     "italian": "it",
     "japanese": "ja",
     "lithuanian": "lt",
@@ -229,7 +230,9 @@ DEEPL_LANGUAGE_TO_CODE = {
     "slovak": "sk",
     "slovenian": "sl",
     "swedish": "sv",
-    "chinese": "zh",
+    "turkish": "tr",
+    "ukrainian": "uk",
+    "chinese": "zh",    
 }
 
 PAPAGO_LANGUAGE_TO_CODE = {


### PR DESCRIPTION
New languages according to the [DeepL API Docs](https://www.deepl.com/docs-api/translate-text/translate-text/):

- Turkish
- Ukrainian
- Indonesian