### PR TITLE
Fix Broken Link

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -688,7 +688,7 @@ Next Steps
 
 Take a look in the examples folder for more :)
 Contributions are always welcome.
-Read the Contribution guidelines `Here <https://deep-translator.readthedocs.io/en/latest/contributing.html/>`_
+Read the Contribution guidelines `Here <https://deep-translator.readthedocs.io/en/latest/contributing.html#get-started>`_
 
 ==========
 Credits

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -656,7 +656,7 @@ Finally, to retrieve a list of available languages for a given translator:
 Tests
 ======
 
-Developers can install the development version of deep-translator and execute unit tests to verify functionality. For more information on doing this, see `the contribution guidelines <https://deep-translator.readthedocs.io/en/latest/contributing.html/>`_
+Developers can install the development version of deep-translator and execute unit tests to verify functionality. For more information on doing this, see `the contribution guidelines <https://deep-translator.readthedocs.io/en/latest/contributing.html#get-started>`_
 
 ========
 Links


### PR DESCRIPTION
I fixed this issue: https://github.com/nidhaloff/deep-translator/issues/172

the correct link is: https://deep-translator.readthedocs.io/en/latest/contributing.html#get-started

- [x] run pytest(poetry run pytest -ra)