### PR TITLE
Reducing the number of API calls on large batch translations

### DIFF
--- a/deep_translator/base.py
+++ b/deep_translator/base.py
@@ -27,6 +27,7 @@ class BaseTranslator(ABC):
         payload_key: Optional[str] = None,
         element_tag: Optional[str] = None,
         element_query: Optional[dict] = None,
+        already_translated: dict[str, str] = {},
         **url_params,
     ):
         """
@@ -35,6 +36,7 @@ class BaseTranslator(ABC):
         """
         self._base_url = base_url
         self._languages = languages
+        self._already_translated = already_translated
         self._supported_languages = list(self._languages.keys())
         if not source:
             raise InvalidSourceOrTargetLanguage(source)
@@ -177,7 +179,11 @@ class BaseTranslator(ABC):
         if not batch:
             raise Exception("Enter your text list that you want to translate")
         arr = []
-        for i, text in enumerate(batch):
-            translated = self.translate(text, **kwargs)
+        for _i, text in enumerate(batch):
+            if text in self._already_translated.keys:
+                translated = self._already_translated[text]
+            else:
+                translated = self.translate(text, **kwargs)
+                self._already_translated[text] = translated
             arr.append(translated)
         return arr


### PR DESCRIPTION
An API call is made for each item in translate_batch, even if the same item is repeated a hundred of times. This is slow. That is why my pull request aims to fix that:

1. When a new batch item is translated, it is stored in a dictionary of already_translated items. The key for the translation in this dictionary is the previously untranslated sentence. 
2. The next item in the batch is then checked against the keys of already_translated items and, if an identical match is found, uses the existing translation.
3. If there is no identical match, an API call is made for the translation.

Even with hundreds of items in a dictionary, checking against its keys is significantly faster than an API call.

The best part is that the already_translated dictionary will be used for the next big batch because it is initialized with the BaseTranslator class. In short, this means that only unique items will require an API call, while repeated items will be translated swiftly.

example:

``` python
translator = LibreTranslator(source='auto', target='es')
batch = ['Hello world', 'I am a python', 'Hello world', 'Hello world', 'I am a python']

translated_batch = translator.translate_batch(batch)
# API call (slow)
# API call (slow)
# Already translated (fast)
# Already translated (fast)
# Already translated (fast)
# Batch translation finished

# translator._already_translated = {
#   'Hello world' : 'Hola mundo',
#   'I am a python' : 'Soy un pitón'
# }
```

