### PR TITLE
typo in the documentation

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -469,7 +469,7 @@ PONS Translator
 
 .. code-block:: python
 
-    translated_words = LingueeTranslator(source='english', target='french').translate_words(["good", "awesome"])
+    translated_words = PonsTranslator(source='english', target='french').translate_words(["good", "awesome"])
 
 Yandex Translator
 ------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -259,7 +259,7 @@ PONS Translator
 
 .. code-block:: python
 
-    translated_words = LingueeTranslator(source='english', target='french').translate_words(["good", "awesome"])
+    translated_words = PonsTranslator(source='english', target='french').translate_words(["good", "awesome"])
 
 Yandex Translator
 ------------------


### PR DESCRIPTION
Both README.rst and usage.rst files used LingueeTranslator instead of PonsTranslator to show how to use PonsTranslator to translate a batch of words.