### PR TITLE
Rewrite `GoogleTranslator.translate_batch` method to require only one API call for the whole list of words (`batch`)

### DIFF
--- a/deep_translator/google.py
+++ b/deep_translator/google.py
@@ -119,4 +119,9 @@ class GoogleTranslator(BaseTranslator):
         @param batch: list of texts you want to translate
         @return: list of translations
         """
-        return self._translate_batch(batch, **kwargs)
+        if not batch:
+            raise Exception("Enter your text list that you want to translate")
+        text = '\n'.join(batch)
+        translated = self.translate(text, **kwargs)
+        arr = translated.split('\n')
+        return arr


### PR DESCRIPTION
I noticed that it's possible to take advantage of the fact that Google Translate can handle multiple words at a time to speed up the `translate_batch` method. In this case, if instead of using `BaseTranslator._translate_batch` for the `GoogleTranslator.translate_batch` method, we can instead join the `batch` list with linebreaks, run a single `translate` call on the entire string, and then split the translated string again by linebreaks to return the `arr` list of results. This way, we don't need to loop through multiple API calls via the `translate` method, rather can get the same set of results with only one API call.

I have tried a number of adhoc test cases by choosing random lists of strings and have found that the result is always identical to what you get when running the current method; however, before formalizing tests for this I wanted to submit it and see whether this idea has already been attempted and whether it was found lacking for some reason that I haven't noticed yet. Basically interested in feedback on the idea.