### PR TITLE
Extend Google languages to include European Portuguese

### DIFF
--- a/deep_translator/constants.py
+++ b/deep_translator/constants.py
@@ -125,6 +125,7 @@ GOOGLE_LANGUAGES_TO_CODES = {
     "persian": "fa",
     "polish": "pl",
     "portuguese": "pt",
+    "portuguese (portugal)": "pt-PT",
     "punjabi": "pa",
     "quechua": "qu",
     "romanian": "ro",

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -57,6 +57,14 @@ def test_payload(google_translator):
 
 
 def test_one_character_words():
-    assert (
-        GoogleTranslator(source="es", target="en").translate("o") is not None
-    )
+    assert GoogleTranslator(source="es", target="en").translate("o") is not None
+
+
+def test_european_portuguese():
+    engine_pt = GoogleTranslator(source="en", target="pt-PT")
+    translation_pt = engine_pt.translate("The bus arrived late")
+    assert translation_pt == "O autocarro chegou atrasado"
+
+    engine_br = GoogleTranslator(source="en", target="pt")
+    translation_br = engine_br.translate("The bus arrived late")
+    assert translation_br == "O ônibus chegou atrasado"


### PR DESCRIPTION
Google has just extended the amount of languages supported [[article]](https://blog.google/products/translate/google-translate-new-languages-2024/). This pull requests adds support to one of those, "Portuguese (Portugal)".