### PR TITLE
update DeeplTranslator to use POST request with authorization header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ ENV/
 
 # IDE settings
 .vscode/
+.history

--- a/deep_translator/deepl.py
+++ b/deep_translator/deepl.py
@@ -69,16 +69,18 @@ class DeeplTranslator(BaseTranslator):
 
             # Create the request parameters.
             translate_endpoint = "translate"
-            params = {
-                "auth_key": self.api_key,
+            headers = {
+                "Authorization": f"DeepL-Auth-Key {self.api_key}"
+            }
+            data = {
                 "source_lang": self._source,
                 "target_lang": self._target,
                 "text": text,
             }
             # Do the request and check the connection.
             try:
-                response = requests.get(
-                    self._base_url + translate_endpoint, params=params
+                response = requests.post(
+                    self._base_url + translate_endpoint, data=data, headers=headers
                 )
             except ConnectionError:
                 raise ServerException(503)


### PR DESCRIPTION
## Description
This PR updates the `DeeplTranslator` to support the recent breaking changes in the DeepL API (effective March 2025).

## Changes
- Changed request method from `GET` to `POST`.
- Moved authentication from query parameters to the `Authorization` header using the `DeepL-Auth-Key` scheme.
- Moved parameters (`text`, `source_lang`, `target_lang`) to the request body.

## Motivation
DeepL has deprecated GET requests for translation and the use of `auth_key` as a query parameter. See: [DeepL Breaking Changes Notice](https://developers.deepl.com/docs/resources/breaking-changes-change-notices/march-2025-deprecating-get-requests-to-translate-and-authenticating-with-auth_key).

Fixes #299

@nothead31
@cboutaud